### PR TITLE
Oppdaterer modellkatalogen

### DIFF
--- a/src/model/catalog-of-models-for-specifications.ttl
+++ b/src/model/catalog-of-models-for-specifications.ttl
@@ -206,4 +206,4 @@
    rdfs:seeAlso <https://informasjonsforvaltning.github.io/xkos-ap-no/#ForenkletModell>;
    .
  
-#### End of the file, 2023-03-09 08:07:10
+#### End of the file, 2023-03-09 08:51:34


### PR DESCRIPTION
Trigger en gang til oppdatering av innholdet i katalogfilen (retter opp feilen at f.eks. dcat-ap-no-png manglet egenskapene dct:title osv.)